### PR TITLE
KM-2-add-config-to-consumer-service

### DIFF
--- a/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/config/KafkaConfig.java
+++ b/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/config/KafkaConfig.java
@@ -1,0 +1,33 @@
+package com.github.tennyros.emailnotificationservice.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.Map;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> conf = kafkaProperties.buildConsumerProperties();
+        return new DefaultKafkaConsumerFactory<>(conf);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+            ConsumerFactory<String, Object> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        return factory;
+    }
+}

--- a/modules/email-notification-service/src/main/resources/application.yml
+++ b/modules/email-notification-service/src/main/resources/application.yml
@@ -11,4 +11,4 @@ spring:
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         value.deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
         group.id: product-created-events
-        spring.json.trusted.packages: "**"
+        spring.json.trusted.packages: com.github.tennyros.eventmodels.event


### PR DESCRIPTION
**What was done:**
- created a new `KafkaConfig` class in `email-notification-service` to handle Kafka consumer configuration;
- defined a `consumerFactory` bean to set up Kafka consumer properties based on `KafkaProperties`;
- created a `kafkaListenerContainerFactory` bean for managing Kafka listeners;
- modified the `application.yml` file to configure trusted package for JSON deserialization, allowing deserialization of event classes from `com.github.tennyros.eventmodels.event`.

**Why this is needed:**
- centralizing Kafka configuration in a dedicated class ensures better maintainability and clarity, simplifying future updates and customizations;
- using the `KafkaProperties` to build consumer properties ensures alignment with Spring Kafka’s conventions, improving configuration consistency across services;
- specifying trusted packages for JSON deserialization ensures that only safe classes are deserialized, preventing deserialization vulnerabilities and errors in production;
- setting up a Kafka listener container factory prepares `email-notification-service` for future consumption of Kafka events, improving decoupling and modularity of services.

**How to test:**
- build `email-notification-service` to ensure proper application of the Kafka configuration;
- run `email-notification-service` and check the application logs to ensure no deserialization errors occur;
- verify that the application is correctly consuming messages from the Kafka topic (using a product-service producer to send events);
- test the deserialization process by ensuring that events from the trusted package (`com.github.tennyros.eventmodels.event`) are processed without errors.

**Links:**
Jira ticket: [KM-2](https://tennyros.atlassian.net/browse/KM-2)

[KM-2]: https://tennyros.atlassian.net/browse/KM-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ