### PR TITLE
KM-4-add-docker-compose.yml-file-to-start-kafka-servers-cluster kafka services, change log message in listen method of event handler email-notif-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+services:
+  kafka-1:
+    image: bitnami/kafka:latest
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_KRAFT_CLUSTER_ID=Chj53bYsQPSXKxLkGQvjMQ
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9091,2@kafka-2:9091,3@kafka-3:9091
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9090,CONTROLLER://:9091,EXTERNAL://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9090,EXTERNAL://${HOSTNAME:-localhost}:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+    volumes:
+      - /var/log/kafka/docker-compose/volumes/server-1/:/bitnami/kafka
+
+
+  kafka-2:
+    image: bitnami/kafka:latest
+    ports:
+      - "9094:9094"
+    environment:
+      - KAFKA_CFG_NODE_ID=2
+      - KAFKA_KRAFT_CLUSTER_ID=Chj53bYsQPSXKxLkGQvjMQ
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9091,2@kafka-2:9091,3@kafka-3:9091
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9090,CONTROLLER://:9091,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-2:9090,EXTERNAL://${HOSTNAME:-localhost}:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+    volumes:
+      - /var/log/kafka/docker-compose/volumes/server-2/:/bitnami/kafka
+
+  kafka-3:
+    image: bitnami/kafka:latest
+    ports:
+      - "9096:9096"
+    environment:
+      - KAFKA_CFG_NODE_ID=3
+      - KAFKA_KRAFT_CLUSTER_ID=Chj53bYsQPSXKxLkGQvjMQ
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka-1:9091,2@kafka-2:9091,3@kafka-3:9091
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9090,CONTROLLER://:9091,EXTERNAL://:9096
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-3:9090,EXTERNAL://${HOSTNAME:-localhost}:9096
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+    volumes:
+      - /var/log/kafka/docker-compose/volumes/server-3/:/bitnami/kafka

--- a/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/handler/ProductCreatedEventHandler.java
+++ b/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/handler/ProductCreatedEventHandler.java
@@ -24,7 +24,7 @@ public class ProductCreatedEventHandler {
 
     @KafkaHandler
     public void listen(ProductCreatedEvent event) {
-        log.info("Received product created event: {}", event.getTitle());
+        log.info("Received product created event: {}, productId: {}", event.getTitle(), event.getProductId());
 
         String url = "http://localhost:8090/response/200";
         try {


### PR DESCRIPTION
**What was done:**
- added docker-compose.yml to create a Kafka cluster with three brokers (kafka-1, kafka-2, kafka-3) using Bitnami’s Kafka image;
- configured each broker with unique NODE_ID and shared KAFKA_KRAFT_CLUSTER_ID;
- set up listeners (PLAINTEXT, CONTROLLER, EXTERNAL) and exposed ports 9092, 9094, 9096;
- mounted persistent volumes for logs and data (/var/log/kafka/docker-compose/volumes).

**Why this is needed:**
- ensures fault tolerance with multiple brokers;
- supports external connections to Kafka;
- persists data across container restarts.

**How to test:**
- run docker-compose up -d to start the cluster and ensure all three Kafka brokers are running;
- use docker ps to verify each broker is healthy and exposed on the correct ports (9092, 9094, 9096);
- produce a test message to a Kafka topic and consume it using an external Kafka client or existing project services to validate cross-broker communication;
- inspect logs in /var/log/kafka/docker-compose/volumes/server-{1,2,3} to confirm each broker processes events as expected.

Links:
 Jira ticket:[ KM-4](https://tennyros.atlassian.net/browse/KM-4)