### PR TITLE
KM-5-add-idempotent-consumer-realization-with-db-transaction consumer

### DIFF
--- a/modules/email-notification-service/pom.xml
+++ b/modules/email-notification-service/pom.xml
@@ -40,8 +40,16 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/handler/ProductCreatedEventHandler.java
+++ b/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/handler/ProductCreatedEventHandler.java
@@ -2,14 +2,21 @@ package com.github.tennyros.emailnotificationservice.handler;
 
 import com.github.tennyros.emailnotificationservice.exception.NonRetryableException;
 import com.github.tennyros.emailnotificationservice.exception.RetryableException;
+import com.github.tennyros.emailnotificationservice.persistence.entity.ProcessedEventEntity;
+import com.github.tennyros.emailnotificationservice.persistence.repository.ProcessedEventRepository;
 import com.github.tennyros.eventmodels.event.ProductCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
@@ -21,13 +28,25 @@ import org.springframework.web.client.RestTemplate;
 public class ProductCreatedEventHandler {
 
     private final RestTemplate restTemplate;
+    private final ProcessedEventRepository processedEventRepository;
 
     @KafkaHandler
-    public void listen(ProductCreatedEvent event) {
-        log.info("Received product created event: {}, productId: {}", event.getTitle(), event.getProductId());
+    @Transactional
+    public void handle(@Payload ProductCreatedEvent productCreatedEvent,
+                       @Header("messageId") String messageId,
+                       @Header(KafkaHeaders.RECEIVED_KEY) String messageKey) {
 
-        String url = "http://localhost:8090/response/200";
+        log.info("Received product created event: {}, productId: {}", productCreatedEvent.getTitle(), productCreatedEvent.getProductId());
+
+        ProcessedEventEntity eventEntity = processedEventRepository.findByMessageId(messageId);
+
+        if (eventEntity != null) {
+            log.info("Duplicate message id: {}", messageId);
+            return;
+        }
+
         try {
+            String url = "http://localhost:8090/response/200";
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, null, String.class);
             if (response.getStatusCode().is2xxSuccessful()) {
                 log.info("Received response: {}", response.getBody());
@@ -40,6 +59,13 @@ public class ProductCreatedEventHandler {
             throw new NonRetryableException(e);
         } catch (Exception e) {
             log.error("Exception: {}", e.getMessage());
+            throw new NonRetryableException(e);
+        }
+
+        try {
+            processedEventRepository.save(new ProcessedEventEntity(messageId, productCreatedEvent.getProductId()));
+        } catch (DataIntegrityViolationException e) {
+            log.error(e.getMessage());
             throw new NonRetryableException(e);
         }
     }

--- a/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/persistence/entity/ProcessedEventEntity.java
+++ b/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/persistence/entity/ProcessedEventEntity.java
@@ -1,0 +1,33 @@
+package com.github.tennyros.emailnotificationservice.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@Table(name = "processed_events")
+public class ProcessedEventEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String messageId;
+
+    @Column(nullable = false)
+    private String productId;
+
+    public ProcessedEventEntity(String messageId, String productId) {
+        this.messageId = messageId;
+        this.productId = productId;
+    }
+}

--- a/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/persistence/repository/ProcessedEventRepository.java
+++ b/modules/email-notification-service/src/main/java/com/github/tennyros/emailnotificationservice/persistence/repository/ProcessedEventRepository.java
@@ -1,0 +1,11 @@
+package com.github.tennyros.emailnotificationservice.persistence.repository;
+
+import com.github.tennyros.emailnotificationservice.persistence.entity.ProcessedEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProcessedEventRepository extends JpaRepository<ProcessedEventEntity, Long> {
+
+    ProcessedEventEntity findByMessageId(String messageId);
+}

--- a/modules/email-notification-service/src/main/resources/application.yml
+++ b/modules/email-notification-service/src/main/resources/application.yml
@@ -4,6 +4,18 @@ server:
 spring:
   application:
     name: email-notification-service
+
+  datasource:
+    username: test
+    password: test
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+
   kafka:
     bootstrap-servers: localhost:9092,localhost:9094
     consumer:

--- a/modules/product-service/src/main/java/com/github/tennyros/productservice/service/impl/ProductServiceImpl.java
+++ b/modules/product-service/src/main/java/com/github/tennyros/productservice/service/impl/ProductServiceImpl.java
@@ -5,6 +5,7 @@ import com.github.tennyros.productservice.service.ProductService;
 import com.github.tennyros.productservice.service.dto.CreateProductDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
@@ -31,28 +32,20 @@ public class ProductServiceImpl implements ProductService {
                 .quantity(createProductDto.getQuantity())
                 .build();
 
+        ProducerRecord<String, ProductCreatedEvent> productCreatedRecord = new ProducerRecord<>(
+                "product-created-events-topic",
+                productId,
+                productCreatedEvent
+        );
+
+        productCreatedRecord.headers().add("messageId", "message-id".getBytes());
+
         SendResult<String, ProductCreatedEvent> result = kafkaTemplate
-                .send("product-created-events-topic", productId, productCreatedEvent).get();
+                .send(productCreatedRecord).get();
 
         log.info("Topic: {}", result.getRecordMetadata().topic());
         log.info("Partition: {}", result.getRecordMetadata().partition());
         log.info("Offset: {}", result.getRecordMetadata().offset());
-
-/*        // for async realization
-        CompletableFuture<SendResult<String, ProductCreatedEvent>> future = kafkaTemplate
-                .send("product-created-events-topic", productId, productCreatedEvent);
-
-        future.whenComplete((result, exception) -> {
-            if (exception != null) {
-                log.error("Failed to send message: {}", exception.getMessage());
-            } else {
-                log.info("Message sent successfully: {}", result.getRecordMetadata());
-            }
-        });
-
-        */
-
-//        future.join();
 
         log.info("Return: {}", productId);
 


### PR DESCRIPTION
**What was done:**
- updated ProductServiceImpl to create ProducerRecord with a messageId header and send it via kafkaTemplate;
- added spring-boot-starter-data-jpa and h2 dependencies to email-notification-service pom.xml;
- created ProcessedEventEntity and ProcessedEventRepository to store processed message IDs;
- modified handle method in ProductCreatedEventHandler to include idempotency check, preventing duplicate message processing and handling DB integrity violations.

**Why this is needed:**
- ensures message processing is idempotent, preventing duplicates from triggering repeated actions;
- introduces persistent storage of processed message IDs for reliability across service restarts;
- supports transactional behavior to ensure message handling and event persistence occur atomically.

**How to test:**
- run docker-compose up -d to start Kafka cluster;
- send a ProductCreatedEvent message with product-service;
- verify email-notification-service processes the event and logs the message ID in the database (processed_events table);
- resend the same event and confirm it logs Duplicate message id without processing again;
- test with DB constraints by forcing a duplicate save to ensure NonRetryableException is thrown on conflict.

Links:
Jira ticket: [KM-5](https://tennyros.atlassian.net/browse/KM-5)

[KM-5]: https://tennyros.atlassian.net/browse/KM-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ