### PR TITLE
KM-6-refactor-kafka-producer-config-in-product-service

### DIFF
--- a/modules/product-service/src/main/java/com/github/tennyros/productservice/config/KafkaConfig.java
+++ b/modules/product-service/src/main/java/com/github/tennyros/productservice/config/KafkaConfig.java
@@ -3,6 +3,8 @@ package com.github.tennyros.productservice.config;
 import com.github.tennyros.eventmodels.event.ProductCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
@@ -15,30 +17,27 @@ import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(KafkaPropertiesConfig.class)
 public class KafkaConfig {
 
     private final KafkaPropertiesConfig kafkaProperties;
 
     @Bean
-    public Map<String, Object> producerConfigs() {
-        return new HashMap<>(kafkaProperties.getProperties());
+    ProducerFactory<String, ProductCreatedEvent> producerFactory(KafkaProperties kafkaProperties) {
+        Map<String, Object> conf = new HashMap<>(kafkaProperties.buildProducerProperties());
+        return new DefaultKafkaProducerFactory<>(conf);
     }
 
     @Bean
-    public ProducerFactory<String, ProductCreatedEvent> productFactory() {
-        return new DefaultKafkaProducerFactory<>(producerConfigs());
-    }
-
-    @Bean
-    public KafkaTemplate<String, ProductCreatedEvent> kafkaTemplate() {
-        return new KafkaTemplate<>(productFactory());
+    KafkaTemplate<String, ProductCreatedEvent> kafkaTemplate(ProducerFactory<String, ProductCreatedEvent> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
     }
 
     @Bean
     public NewTopic createTopic() {
-        return TopicBuilder.name("product-created-events-topic")
-                .partitions(3)
-                .replicas(3)
+        return TopicBuilder.name(kafkaProperties.getTopics().get("product-created"))
+                .partitions(kafkaProperties.getPartitions())
+                .replicas(kafkaProperties.getReplicas())
                 .configs(Map.of("min.insync.replicas", "2"))
                 .build();
     }

--- a/modules/product-service/src/main/java/com/github/tennyros/productservice/config/KafkaPropertiesConfig.java
+++ b/modules/product-service/src/main/java/com/github/tennyros/productservice/config/KafkaPropertiesConfig.java
@@ -1,18 +1,18 @@
 package com.github.tennyros.productservice.config;
 
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @Getter
-@Setter
-@Configuration
-@ConfigurationProperties(prefix = "spring.kafka.producer")
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "app.kafka")
 public class KafkaPropertiesConfig {
 
-    private Map<String, String> properties = new HashMap<>();
+    private final Map<String, String> topics;
+    private final int partitions;
+    private final int replicas;
+
 }

--- a/modules/product-service/src/main/java/com/github/tennyros/productservice/service/dto/CreateProductDto.java
+++ b/modules/product-service/src/main/java/com/github/tennyros/productservice/service/dto/CreateProductDto.java
@@ -1,6 +1,7 @@
 package com.github.tennyros.productservice.service.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import java.math.BigDecimal;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateProductDto {

--- a/modules/product-service/src/main/resources/application.yml
+++ b/modules/product-service/src/main/resources/application.yml
@@ -5,14 +5,21 @@ spring:
   application:
     name: product-service
   kafka:
+    bootstrap-servers: localhost:9092,localhost:9094
     producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
       properties:
-        bootstrap.servers: localhost:9092,localhost:9094
-        key.serializer: org.apache.kafka.common.serialization.StringSerializer
-        value.serializer: org.springframework.kafka.support.serializer.JsonSerializer
-        acks: all
         enable.idempotence: true
         max.in.flight.requests.per.connection: 5
         delivery.timeout.ms: 20000
         linger.ms: 0
         request.timeout.ms: 10000
+
+app:
+  kafka:
+    topics:
+      product-created: product-created-events-topic
+    partitions: 3
+    replicas: 3


### PR DESCRIPTION
**What was done:**

- refactored `KafkaConfig` to use `@EnableConfigurationProperties` and injected `KafkaPropertiesConfig` for better configuration handling;
- updated `application.yml` to separate Kafka producer properties and custom topic settings under `app.kafka`;
- modified `KafkaPropertiesConfig` to map topic names, partitions, and replicas from `application.yml`;
- added `@Builder` to `CreateProductDto` to improve readability and simplify object creation in tests and services.

**Why this is needed:**
- separating Kafka topic configuration allows easier topic management and reusability across different services;
- `@EnableConfigurationProperties` ensures proper binding of custom configurations without manual bean initialization;
- `@Builder` in `CreateProductDto` improves test readability and reduces boilerplate code during object creation.

**How to test:**
- run the product-service with the updated `application.yml` configuration;
- ensure the product-created-events-topic is created with the correct number of partitions and replicas;
- verify product creation produces an event to Kafka without serialization errors;
- ensure that already existing logic with product-service, mock-service and product-service is working correctly.

**Links:**
 Jira ticket:[KM-6](https://tennyros.atlassian.net/browse/KM-6)

[KM-6]: https://tennyros.atlassian.net/browse/KM-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ