### PR TITLE
KM-8-add-ci-git-action-build-test-telegram-notification-flow

### DIFF
--- a/.github/workflows/mvn-install-ci.yml
+++ b/.github/workflows/mvn-install-ci.yml
@@ -7,6 +7,7 @@ on:
       - feature/*
       - test/*
       - hotfix/*
+      - 'KM-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/mvn-install-ci.yml
+++ b/.github/workflows/mvn-install-ci.yml
@@ -1,0 +1,57 @@
+name: CI Pipeline with Maven
+
+on:
+  push:
+    branches:
+      - ci-issues
+      - feature/*
+      - test/*
+      - hotfix/*
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Grant execute permission for mvnw
+        run: chmod +x mvnw
+
+      - name: Build with Maven
+        run: ./mvnw -B package --file pom.xml
+
+      - name: Send Telegram notification
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          STATUS="${{ job.status }}"
+
+          MESSAGE="🚀 CI Pipeline Status: ${STATUS}
+
+          Project: \#$(basename ${{ github.repository }} | sed 's/-/\\-/g')
+          Branch: \`${{ github.ref }}\`
+          Commit: \`${{ github.sha }}\`
+
+          [Details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+          curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+          -d "chat_id=${TELEGRAM_CHAT_ID}" \
+          -d "text=${MESSAGE}" \
+          -d "parse_mode=MarkdownV2"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Kafka-module-services
+
+![CI with Maven](https://github.com/tennyros/kafka-module-services/workflows/CI%20Pipeline%20with%20Maven/badge.svg)


### PR DESCRIPTION
**What was done:**
- added `mvn-install-ci.yml` to configure CI pipeline for Maven build and tests;  
- set up Java 17 with Maven caching to speed up builds;  
- granted execute permission to `mvnw` script for proper execution;  
- configured pipeline to build project and run tests using `./mvnw -B package`;  
- implemented Telegram notification to inform about pipeline status;  
- added CI badge to `README.md` to show build status.

**Why this is needed:**
- automates build, test, and notification process for more efficient development;  
- maven caching reduces build time for repeated tasks;  
- telegram notifications provide quick feedback on pipeline status;  
- CI badge in `README.md` displays the real-time build status for the project.

**How to test:**
- push changes or create a PR to trigger the CI pipeline;  
- check if the build completes successfully with tests;  
- verify that Telegram notification is sent with the pipeline status;  
- ensure the CI badge in `README.md` reflects the correct status.

**Links:**
Jira ticket: [KM-8](https://tennyros.atlassian.net/browse/KM-8)


[KM-8]: https://tennyros.atlassian.net/browse/KM-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ