### PR TITLE
KM-10-add-IT-producer-config-test

### DIFF
--- a/modules/product-service/src/test/java/com/github/tennyros/productservice/integration/kafka/producer/IdempotentProducerIT.java
+++ b/modules/product-service/src/test/java/com/github/tennyros/productservice/integration/kafka/producer/IdempotentProducerIT.java
@@ -1,0 +1,45 @@
+package com.github.tennyros.productservice.integration.kafka.producer;
+
+import com.github.tennyros.eventmodels.event.ProductCreatedEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Map;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class IdempotentProducerIT {
+
+    @Autowired
+    private KafkaTemplate<String, ProductCreatedEvent> kafkaTemplate;
+
+    @MockitoBean
+    private KafkaAdmin kafkaAdmin;
+
+    @Test
+    void testProducerConfig_whenIdempotenceEnabled_assertsIdempotentProperties() {
+        ProducerFactory<String, ProductCreatedEvent> producerFactory = kafkaTemplate.getProducerFactory();
+        Map<String, Object> config = producerFactory.getConfigurationProperties();
+
+        assertAll(
+                () -> assertEquals("true", config.get(ENABLE_IDEMPOTENCE_CONFIG)),
+                () -> assertTrue("all".equalsIgnoreCase(config.get(ACKS_CONFIG).toString())),
+                () -> {
+                    if (config.containsKey(RETRIES_CONFIG)) {
+                        assertTrue(Integer.parseInt(config.get(RETRIES_CONFIG).toString()) > 0);
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
***What was done:**

- added IdempotentProducerIT integration test to verify Kafka producer idempotence settings;
- used `@SpringBootTest` to set up the test environment with an autowired KafkaTemplate;
- mocked KafkaAdmin using @MockitoBean to isolate the test scope;
- retrieved producer configuration properties and asserted key settings:
- enable.idempotence=true to ensure idempotent message production;
- acks=all for strong delivery guarantees;
-positive retries value to allow automatic retries on transient failures.

**Why this is needed:**
- ensures that the Kafka producer is correctly configured for idempotent message delivery;
- prevents duplicate events by verifying idempotence settings in a controlled test environment;
- enhances reliability and fault tolerance of Kafka-based microservices.

**How to test:**

- run IdempotentProducerIT and check that all assertions pass;
- modify producer properties in the application config and verify test behavior;
- check logs to confirm the expected Kafka producer settings are applied.

**Links:**
Jira ticket: [KM-10](https://tennyros.atlassian.net/browse/KM-10)

[KM-10]: https://tennyros.atlassian.net/browse/KM-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ